### PR TITLE
Potential fix for code scanning alert no. 13: Database query built from user-controlled sources

### DIFF
--- a/routes/team.js
+++ b/routes/team.js
@@ -137,9 +137,18 @@ router.put('/:id', [
       });
     }
 
+    // Only allow whitelisted fields to be updated
+    const allowedFields = ['name', 'title', 'bio', 'email', 'department', 'category'];
+    const updateData = {};
+    for (const field of allowedFields) {
+      if (Object.prototype.hasOwnProperty.call(req.body, field)) {
+        updateData[field] = req.body[field];
+      }
+    }
+
     const teamMember = await TeamMember.findByIdAndUpdate(
       req.params.id,
-      req.body,
+      updateData,
       { new: true, runValidators: true }
     );
 


### PR DESCRIPTION
Potential fix for [https://github.com/darefat/kfsquare/security/code-scanning/13](https://github.com/darefat/kfsquare/security/code-scanning/13)

To fix this problem, we should ensure that the update object passed to Mongoose is constructed only from whitelisted, validated user data, and not directly from `req.body`. The best pattern is to explicitly build a new update object containing only the allowed fields, filtering out any unknown/unexpected or dangerous properties, and passing this to the update call.

**Steps:**
- After validation, construct a new update object by picking only the allowed fields (`name`, `title`, `bio`, `email`, `department`, `category`) from `req.body`, and only if they are present.
- Pass this sanitized update object to `findByIdAndUpdate`.
- Consider using a small utility or method for this purpose (can be inline for clarity).
- **No need to install external dependencies**; use native JS.

**Regions to change:** In the PUT `/team/:id` handler (lines 130–166), just before calling `findByIdAndUpdate`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
